### PR TITLE
Fix library callback / cater for fb2k v1 on startup

### DIFF
--- a/src/initquit.cpp
+++ b/src/initquit.cpp
@@ -3,23 +3,30 @@
 #include "foobar2000/SDK/library_callbacks.h"
 #include "PlayedTimes.h"
 
-
-class myLibraryCallbacks : public library_callback_v2_dynamic_impl_base {
+class myLibraryCallbacks : public library_callback_v2 {
 public:
-	void on_library_initialized() {
+	void on_library_initialized() final {
 		foo_enhanced_playcount::updateRecentScrobblesThreaded(true);
 	}
+
+	void on_items_added(metadb_handle_list_cref) final {}
+	void on_items_modified(metadb_handle_list_cref) final {}
+	void on_items_removed(metadb_handle_list_cref) final {}
 };
 
 class myinitquit : public initquit {
 public:
-	void on_init() {
+	void on_init() final {
 		console::print(COMPONENT_NAME": loaded");
-		new myLibraryCallbacks();
+		if (!core_version_info_v2::get()->test_version(2, 0, 0, 0))
+		{
+			foo_enhanced_playcount::updateRecentScrobblesThreaded(true);
+		}
 	}
-	void on_quit() {
+	void on_quit() final {
 		console::print(COMPONENT_NAME": unloading");
 	}
 };
 
-static initquit_factory_t<myinitquit> g_myinitquit_factory;
+FB2K_SERVICE_FACTORY(myLibraryCallbacks);
+FB2K_SERVICE_FACTORY(myinitquit);


### PR DESCRIPTION
Following on from my comment on HA [here](https://hydrogenaud.io/index.php/topic,115227.msg1022701.html#msg1022701).