### PR TITLE
Fix mutex crash

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -2,6 +2,7 @@
 
 #define _WIN32_WINNT _WIN32_WINNT_WIN7
 #define WINVER _WIN32_WINNT_WIN7
+#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 
 #include <algorithm>
 #include <atomic>


### PR DESCRIPTION
VS 2022 17.10 introduced a change that causes code using std::mutex code to crash when C++ runtimes are outdated.

fb2k 2.24 and newer include runtimes that are new enough so they are unaffected and probably why you don't encounter problems during testing. But anyone using older fb2k is getting burned.

The workaround comes from the 17.10 release notes here...

https://github.com/microsoft/STL/releases/tag/vs-2022-17.10

Fixes https://github.com/kbuffington/foo_enhanced_playcount/issues/16